### PR TITLE
Non-ERC721 compliant Governance NFT

### DIFF
--- a/contracts/GovernanceNFT.sol
+++ b/contracts/GovernanceNFT.sol
@@ -32,14 +32,24 @@ contract GovernanceNFT {
   function ownerOf(uint tokenId) external view returns (address owner) {
     return _ownerOf[tokenId];
   }
-   
+
   function transferFrom(address from, address to, uint tokenId) onlyElectionContractCanCall public {
     require(msg.sender != _ownerOf[tokenId], "Operation denied. Caller is not authorised to transfer from's tokens.");
     require(from == _ownerOf[tokenId], "Operation denied. From is not the owner of token.");
     require(to != address(0), "transfer to zero address");  
     _balanceOf[from]--;
     _balanceOf[to]++;
-    _ownerOf[tokenId] = to;  
+    _ownerOf[tokenId] = to;
     emit Transfer(from, to, tokenId);
   }
+
+  function mint(address to, uint tokenId) onlyElectionContractCanCall internal {
+    require(to != address(0), "Operation denied. Mint to zero address not allowed.");
+    require(_ownerOf[tokenId] == address(0), "Operation denied. Token already minted.");
+
+    _balanceOf[to]++;
+    _ownerOf[tokenId] = to;
+
+    emit Transfer(address(0), to, tokenId);
+  } 
 }

--- a/contracts/GovernanceNFT.sol
+++ b/contracts/GovernanceNFT.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: UNLICENSED 
+pragma solidity ^0.8.20;
+
+contract GovernanceNFT {
+  // This NFT is non-ERC721 compliant as implementing the ERC721 interface would require there to be 
+  // approved addresses and operators which are unwanted. Furthermore contract accounts will not
+  // own tokens since they will be blocked from registering in the election so the additional assertion
+  // that is required in safeTransferFrom in the ERC721 interface is unnecessary
+
+  event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);  
+
+  address private electionContractAddress;  
+
+  modifier onlyElectionContractCanCall() {
+    require(msg.sender == electionContractAddress);
+    _;
+  }
+
+  constructor(address electionContractAddressParam) {
+    electionContractAddress = electionContractAddressParam;
+  }  
+
+  // Mapping from token ID to owner address
+  mapping(uint => address) internal _ownerOf;  
+  // Mapping owner address to token count
+  mapping(address => uint) internal _balanceOf;  
+
+  function balanceOf(address owner) external view returns (uint balance) {
+    return _balanceOf[owner];
+  }
+
+  function ownerOf(uint tokenId) external view returns (address owner) {
+    return _ownerOf[tokenId];
+  }
+   
+  function transferFrom(address from, address to, uint tokenId) onlyElectionContractCanCall public {
+    require(msg.sender != _ownerOf[tokenId], "Operation denied. Caller is not authorised to transfer from's tokens.");
+    require(from == _ownerOf[tokenId], "Operation denied. From is not the owner of token.");
+    require(to != address(0), "transfer to zero address");  
+    _balanceOf[from]--;
+    _balanceOf[to]++;
+    _ownerOf[tokenId] = to;  
+    emit Transfer(from, to, tokenId);
+  }
+}


### PR DESCRIPTION
- Implemented non-fungible governance token
- Non-ERC721 compliant because implementing ERC721 interface means there would be approved addresses and operators which are unwanted and contract accounts will not own any tokens because they are blocked from registering in the election.
- Modifier onlyElectionContractCanCall applied to transferFrom function. The election contract is the simplified interface to the system.